### PR TITLE
Ensure we handle gracefully the case when the firehose stops retrying

### DIFF
--- a/firehose_exporter.go
+++ b/firehose_exporter.go
@@ -193,7 +193,8 @@ func main() {
 		metricsStore,
 	)
 	go func() {
-		log.Fatal(nozzle.Start())
+		nozzle.Start()
+		os.Exit(1)
 	}()
 
 	internalMetricsCollector := collectors.NewInternalMetricsCollector(*metricsNamespace, *metricsEnvironment, metricsStore)


### PR DESCRIPTION
In one of our environments we've observed that every few days the `firehose_exporter` appears to stop, yet `bosh` thinks it's still alive (and the process sure enough is).

An example log:

```
time="2018-02-16T03:02:43Z" level=info msg="Starting firehose_exporter (version=5.0.1, branch=master, revision=38a5c23be483c97f4d241af85a81a6b4ad4ab9a9)" source="firehose_exporter.go:152"
time="2018-02-16T03:02:43Z" level=info msg="Build context (go=go1.9.2, user=root@3856e24b8b0b, date=20180202-07:01:33)" source="firehose_exporter.go:153"
time="2018-02-16T03:02:43Z" level=info msg="Listening on :9186" source="firehose_exporter.go:230"
time="2018-02-16T03:02:43Z" level=info msg="Starting Firehose Nozzle..." source="firehose_nozzle.go:58"
time="2018-02-19T00:33:12Z" level=error msg="Error while reading from the Firehose: websocket: close 1006 (abnormal closure): unexpected EOF" source="firehose_nozzle.go:111"
time="2018-02-19T01:10:07Z" level=error msg="Error while reading from the Firehose: websocket: close 1006 (abnormal closure): unexpected EOF" source="firehose_nozzle.go:111"
```

and then nothing.

On examination of the code, my belief is that `firehose_nozzle.go` logs this, then sees it as a `RetryError` and then [returns true](https://github.com/bosh-prometheus/firehose_exporter/blob/38a5c23be483c97f4d241af85a81a6b4ad4ab9a9/firehosenozzle/firehose_nozzle.go#L123) continuing back into the `select {}` loop.

On deeper examination of the `FilteredFirehose()` method, it appears that even for a retryable connection, there are a bunch of code paths that will in fact close the channels, and exit. Further, even if a non-retryable error is sent to the channel, it has buffer size of 1, so there is no guarantee it will be read before the messages channel is closed, which could mean that the exporter would read empty values indefinitely rather than catch the actual error.

In any case, this PR makes the following changes:

1. Checks the `ok` value after reading from a channel to check if the channel is closed, and if so, not attempt to read from it again.

2. Stops trying to do logic based on retryable errors or not. This is already managed on the other end, our responsibility is to keep reading from the channels until they are closed (at which time our process should exit).

We'll start testing this in our environments tomorrow. Sending here early in case others are seeing similar.