### PR TITLE
Fix for missing custom metrics.

### DIFF
--- a/metrics/store.go
+++ b/metrics/store.go
@@ -393,7 +393,7 @@ func generateMetricName(envelope *events.Envelope) string {
 	if isItValidUuid {
 		if envelope.Tags != nil {
 			for _, tagValue := range envelope.Tags {
-				name = name + tagValue
+				name = name + utils.NormalizeName(tagValue)
 			}
 		}
 		return name

--- a/metrics/store.go
+++ b/metrics/store.go
@@ -2,6 +2,8 @@ package metrics
 
 import (
 	"bytes"
+	"fmt"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -370,8 +372,32 @@ func (s *Store) metricKey(envelope *events.Envelope) string {
 	case events.Envelope_HttpStartStop:
 		buffer.WriteString(envelope.GetHttpStartStop().GetRequestId().String())
 	case events.Envelope_ValueMetric:
-		buffer.WriteString(envelope.GetValueMetric().GetName())
+		buffer.WriteString(generateMetricName(envelope))
 	}
 
 	return buffer.String()
+}
+
+// Issue:
+// 		https://github.com/bosh-prometheus/firehose_exporter/issues/47
+// Solution:
+// 1. Check if the metric being emitted comes from the container of the app
+// the way we are going to do that is by checking if the origin has a uuid
+// which means its from the container
+// 2. Once detected that is from the app container, then add a little more extra info
+// on the metric name like tags, just to differentiate the metrics and emit all of them
+func generateMetricName(envelope *events.Envelope) string {
+	name := envelope.GetValueMetric().GetName()
+	uuidRegex := "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
+	regexp := regexp.MustCompile(uuidRegex)
+	isItValidUuid := regexp.MatchString(*envelope.Origin)
+	if isItValidUuid {
+		if envelope.Tags != nil {
+			for _, tagValue := range envelope.Tags {
+				name = name + tagValue
+			}
+		}
+		return name
+	}
+	return name
 }

--- a/metrics/store.go
+++ b/metrics/store.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"bytes"
-	"fmt"
 	"regexp"
 	"strconv"
 	"time"


### PR DESCRIPTION
This is a fix for https://github.com/bosh-prometheus/firehose_exporter/issues/47 & https://github.com/bosh-prometheus/firehose_exporter/issues/46

### Problem

With spring actuator attached to sprint boot application  it sends in custom metrics for JVM like one for eg,s

```
jvm_memory_committed_bytes{area="nonheap",id="Code Cache",} 2.392064E7
jvm_memory_committed_bytes{area="nonheap",id="Metaspace",} 5.1904512E7
jvm_memory_committed_bytes{area="nonheap",id="Compressed Class Space",} 6553600.0
jvm_memory_committed_bytes{area="heap",id="Eden Space",} 1.3631488E7
jvm_memory_committed_bytes{area="heap",id="Survivor Space",} 1703936.0
jvm_memory_committed_bytes{area="heap",id="Tenured Gen",} 3.3931264E7
```

with firehoze exported attached, we only obtain one of the metrics from the above

```
# HELP firehose_value_metric_4_efb_41_e_2_9_f_34_4_afe_b_9_e_1_f_0_e_8216_dbf_31_jvm_memory_committed_bytes Cloud Foundry Firehose 'jvm_memory_committed_bytes' value metric from '4efb41e2-9f34-4afe-b9e1-f0e8216dbf31'.
# TYPE firehose_value_metric_4_efb_41_e_2_9_f_34_4_afe_b_9_e_1_f_0_e_8216_dbf_31_jvm_memory_committed_bytes gauge
firehose_value_metric_4_efb_41_e_2_9_f_34_4_afe_b_9_e_1_f_0_e_8216_dbf_31_jvm_memory_committed_bytes{application_guid="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",application_instance="0",area="heap",bosh_deployment="cf-aecd7354c81998985fc3",bosh_job_id="76a2c8
94-2ee6-44da-9ed4-1f7978aa8e69",bosh_job_ip="10.193.83.52",bosh_job_name="control",environment="lab18",id="Tenured Gen",instance_id="0",origin="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",product="Small Footprint PAS",source_id="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",system_domain="run-18.haas-59.pez.pivotal.io",unit=""} 3.3931264e+07
```

which defeats the purpose of getting other vital metrics.

### Cause

Seems like the issue ( on a quick scan of the code ) occurs at this line of the code
https://github.com/bosh-prometheus/firehose_exporter/blob/master/metrics/store.go#L373
Since the name generate via the metrics above is the same for all the 6 variants we endup creating a cache value of single metric thus loosing the remaining 5

### Solution

This pull request fixes the above problem, we check if the metric is coming from container and if it is from the container then we can add a few more extra information to the name 
**NOTE:** this doesn't break any flow", A sample of the metrics now looks like
```
firehose_value_metric_4_efb_41_e_2_9_f_34_4_afe_b_9_e_1_f_0_e_8216_dbf_31_jvm_memory_committed_bytes{application_guid="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",application_instance="0",area="heap",bosh_deployment="cf-aecd7354c81998985fc3",bosh_job_id="76a2c894-2ee6-44da-9ed4-1f7978aa8e69",bosh_job_ip="10.193.83.52",bosh_job_name="control",environment="lab18",id="Eden Space",instance_id="0",origin="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",product="Small Footprint PAS",source_id="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",system_domain="run-18.haas-59.pez.pivotal.io",unit=""} 1.3631488e+07

firehose_value_metric_4_efb_41_e_2_9_f_34_4_afe_b_9_e_1_f_0_e_8216_dbf_31_jvm_memory_committed_bytes{application_guid="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",application_instance="0",area="heap",bosh_deployment="cf-aecd7354c81998985fc3",bosh_job_id="76a2c894-2ee6-44da-9ed4-1f7978aa8e69",bosh_job_ip="10.193.83.52",bosh_job_name="control",environment="lab18",id="Survivor Space",instance_id="0",origin="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",product="Small Footprint PAS",source_id="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",system_domain="run-18.haas-59.pez.pivotal.io",unit=""} 1.703936e+06

firehose_value_metric_4_efb_41_e_2_9_f_34_4_afe_b_9_e_1_f_0_e_8216_dbf_31_jvm_memory_committed_bytes{application_guid="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",application_instance="0",area="heap",bosh_deployment="cf-aecd7354c81998985fc3",bosh_job_id="76a2c8
94-2ee6-44da-9ed4-1f7978aa8e69",bosh_job_ip="10.193.83.52",bosh_job_name="control",environment="lab18",id="Tenured Gen",instance_id="0",origin="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",product="Small Footprint PAS",source_id="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",system_domain="run-18.haas-59.pez.pivotal.io",unit=""} 3.3931264e+07

firehose_value_metric_4_efb_41_e_2_9_f_34_4_afe_b_9_e_1_f_0_e_8216_dbf_31_jvm_memory_committed_bytes{application_guid="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",application_instance="0",area="nonheap",bosh_deployment="cf-aecd7354c81998985fc3",bosh_job_id="76a
2c894-2ee6-44da-9ed4-1f7978aa8e69",bosh_job_ip="10.193.83.52",bosh_job_name="control",environment="lab18",id="Code Cache",instance_id="0",origin="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",product="Small Footprint PAS",source_id="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",system_domain="run-18.haas-59.pez.pivotal.io",unit=""} 2.3789568e+07

firehose_value_metric_4_efb_41_e_2_9_f_34_4_afe_b_9_e_1_f_0_e_8216_dbf_31_jvm_memory_committed_bytes{application_guid="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",application_instance="0",area="nonheap",bosh_deployment="cf-aecd7354c81998985fc3",bosh_job_id="76a2c894-2ee6-44da-9ed4-1f7978aa8e69",bosh_job_ip="10.193.83.52",bosh_job_name="control",environment="lab18",id="Compressed Class Space",instance_id="0",origin="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",product="Small Footprint PAS",source_id="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",system_domain="run-18.haas-59.pez.pivotal.io",unit=""} 6.5536e+06

firehose_value_metric_4_efb_41_e_2_9_f_34_4_afe_b_9_e_1_f_0_e_8216_dbf_31_jvm_memory_committed_bytes{application_guid="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",application_instance="0",area="nonheap",bosh_deployment="cf-aecd7354c81998985fc3",bosh_job_id="76a2c894-2ee6-44da-9ed4-1f7978aa8e69",bosh_job_ip="10.193.83.52",bosh_job_name="control",environment="lab18",id="Metaspace",instance_id="0",origin="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",product="Small Footprint PAS",source_id="4efb41e2-9f34-4afe-b9e1-f0e8216dbf31",system_domain="run-18.haas-59.pez.pivotal.io",unit=""} 5.1904512e+07
```