### PR TITLE
Convert counter_events tags to Prometheus labels

### DIFF
--- a/collectors/counter_events_collector_test.go
+++ b/collectors/counter_events_collector_test.go
@@ -98,6 +98,12 @@ var _ = Describe("CounterEventsCollector", func() {
 			deltaCounterEvent1 prometheus.Metric
 			totalCounterEvent2 prometheus.Metric
 			deltaCounterEvent2 prometheus.Metric
+			
+			tag1Name  = "tag1"
+			tag1Value = "fakeTag1"
+
+			tag2Name  = "tag2"
+			tag2Value = "fakeTag2"
 		)
 
 		BeforeEach(func() {
@@ -114,6 +120,9 @@ var _ = Describe("CounterEventsCollector", func() {
 						Name:  proto.String(counterEvent1Name),
 						Delta: proto.Uint64(counterEvent1Delta),
 						Total: proto.Uint64(counterEvent1Total),
+					},
+					Tags: map[string]string{
+						tag1Name: tag1Value,
 					},
 				},
 			)
@@ -132,6 +141,9 @@ var _ = Describe("CounterEventsCollector", func() {
 						Delta: proto.Uint64(counterEvent2Delta),
 						Total: proto.Uint64(counterEvent2Total),
 					},
+					Tags: map[string]string{
+						tag2Name: tag2Value,
+					},
 				},
 			)
 
@@ -141,7 +153,7 @@ var _ = Describe("CounterEventsCollector", func() {
 				prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "counter_event", counterEvent1OriginNameNormalized+"_"+counterEvent1NameNormalized+"_total"),
 					fmt.Sprintf("Cloud Foundry Firehose '%s' total counter event from '%s'.", counterEvent1DescNormalized, counterEvent1OriginDescNormalized),
-					[]string{"origin", "bosh_deployment", "bosh_job_name", "bosh_job_id", "bosh_job_ip"},
+					[]string{"origin", "bosh_deployment", "bosh_job_name", "bosh_job_id", "bosh_job_ip", tag1Name},
 					prometheus.Labels{"environment": environment},
 				),
 				prometheus.CounterValue,
@@ -151,13 +163,14 @@ var _ = Describe("CounterEventsCollector", func() {
 				boshJob,
 				boshIndex,
 				boshIP,
+				tag1Value,
 			)
 
 			deltaCounterEvent1 = prometheus.MustNewConstMetric(
 				prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "counter_event", counterEvent1OriginNameNormalized+"_"+counterEvent1NameNormalized+"_delta"),
 					fmt.Sprintf("Cloud Foundry Firehose '%s' delta counter event from '%s'.", counterEvent1DescNormalized, counterEvent1OriginDescNormalized),
-					[]string{"origin", "bosh_deployment", "bosh_job_name", "bosh_job_id", "bosh_job_ip"},
+					[]string{"origin", "bosh_deployment", "bosh_job_name", "bosh_job_id", "bosh_job_ip", tag1Name},
 					prometheus.Labels{"environment": environment},
 				),
 				prometheus.GaugeValue,
@@ -167,13 +180,14 @@ var _ = Describe("CounterEventsCollector", func() {
 				boshJob,
 				boshIndex,
 				boshIP,
+				tag1Value,
 			)
 
 			totalCounterEvent2 = prometheus.MustNewConstMetric(
 				prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "counter_event", counterEvent2OriginNameNormalized+"_"+counterEvent2NameNormalized+"_total"),
 					fmt.Sprintf("Cloud Foundry Firehose '%s' total counter event from '%s'.", counterEvent2DescNormalized, counterEvent2OriginDescNormalized),
-					[]string{"origin", "bosh_deployment", "bosh_job_name", "bosh_job_id", "bosh_job_ip"},
+					[]string{"origin", "bosh_deployment", "bosh_job_name", "bosh_job_id", "bosh_job_ip", tag2Name},
 					prometheus.Labels{"environment": environment},
 				),
 				prometheus.CounterValue,
@@ -183,13 +197,14 @@ var _ = Describe("CounterEventsCollector", func() {
 				boshJob,
 				boshIndex,
 				boshIP,
+				tag2Value,
 			)
 
 			deltaCounterEvent2 = prometheus.MustNewConstMetric(
 				prometheus.NewDesc(
 					prometheus.BuildFQName(namespace, "counter_event", counterEvent2OriginNameNormalized+"_"+counterEvent2NameNormalized+"_delta"),
 					fmt.Sprintf("Cloud Foundry Firehose '%s' delta counter event from '%s'.", counterEvent2DescNormalized, counterEvent2OriginDescNormalized),
-					[]string{"origin", "bosh_deployment", "bosh_job_name", "bosh_job_id", "bosh_job_ip"},
+					[]string{"origin", "bosh_deployment", "bosh_job_name", "bosh_job_id", "bosh_job_ip", tag2Name},
 					prometheus.Labels{"environment": environment},
 				),
 				prometheus.GaugeValue,
@@ -199,6 +214,7 @@ var _ = Describe("CounterEventsCollector", func() {
 				boshJob,
 				boshIndex,
 				boshIP,
+				tag2Value,
 			)
 		})
 


### PR DESCRIPTION
Convert counter_events tags to Prometheus labels (similar to https://github.com/bosh-prometheus/firehose_exporter/pull/44).