### PR TITLE
Add missing handler to make FirehoseExporter work again

### DIFF
--- a/firehose_exporter.go
+++ b/firehose_exporter.go
@@ -255,6 +255,7 @@ func main() {
 		Addr:              *listenAddress,
 		ReadTimeout:       time.Second * 5,
 		ReadHeaderTimeout: time.Second * 10,
+		Handler:           router,
 	}
 
 	if *tlsCertFile != "" && *tlsKeyFile != "" {


### PR DESCRIPTION
Before adjustments in this commit https://github.com/bosh-prometheus/firehose_exporter/commit/80a716badee7dd502cd44a1cb1ce70b8fa3c3189 the following lines used router as Handler. 

```

	if *tlsCertFile != "" && *tlsKeyFile != "" {
		log.Infoln("Listening TLS on", *listenAddress)
		log.Fatal(http.ListenAndServeTLS(*listenAddress, *tlsCertFile, *tlsKeyFile, router))
	} else {
		log.Infoln("Listening on", *listenAddress)
		log.Fatal(http.ListenAndServe(*listenAddress, router))
	}

```

when adjusting the section to use http.server router was dropped as handler and default was used which leads to the different endpoints of the exporter not working anymore

```
	server := &http.Server{
		Addr:              *listenAddress,
		ReadTimeout:       time.Second * 5,
		ReadHeaderTimeout: time.Second * 10,
	}

	if *tlsCertFile != "" && *tlsKeyFile != "" {
		log.Infoln("Listening TLS on", *listenAddress)
		err = server.ListenAndServeTLS(*tlsCertFile, *tlsKeyFile)
	} else {
		log.Infoln("Listening on", *listenAddress)
		err = server.ListenAndServe()
	}

	log.Fatal(err)
}


```