### PR TITLE
Keep Test files excluded from dot import check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,12 @@ run:
 output:
   format: line-number
 
+linters-settings:
+  revive:
+    rules:
+    - name: dot-imports
+      exclude: ["**/*_test.go"]
+
 linters:
   disable-all: false
   enable:


### PR DESCRIPTION
The default of the linter was changed (https://github.com/mgechev/revive/issues/883)
I excluded test files again.